### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ To use this extension you need [Alfred.app](http://www.alfredapp.com/) for OS X 
 - `timer 40 Laundry is done!` adds an optional title to the timer.
 - `timer` displays usage information.
 
-##Meta
+## Meta
 
 Daniel Bader – [@dbader_org](https://twitter.com/dbader_org) – mail@dbader.org
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
