### PR TITLE
Fix issue with non-ASCII characters

### DIFF
--- a/Timer/timer.py
+++ b/Timer/timer.py
@@ -141,9 +141,9 @@ def notify(title, subtitle=None):
         return
 
     notification = NSUserNotification.alloc().init()
-    notification.setTitle_(str(title))
+    notification.setTitle_(title.decode('utf-8'))
     if subtitle:
-        notification.setSubtitle_(str(subtitle))
+        notification.setSubtitle_(subtitle.decode('utf-8'))
 
     notification_center = NSUserNotificationCenter.defaultUserNotificationCenter()
     notification_center.deliverNotification_(notification)


### PR DESCRIPTION
Thank you for this powerful productivity tools! But I had some trouble using Chinese as timer's completion messages.

<img width="354" alt="before" src="https://user-images.githubusercontent.com/1492050/76726659-c5cf4900-678c-11ea-9f94-b3c06d5291f6.png">

Then I figured out that `objc` running on python2 bridges `str` and `unicode` in different way. When the message contains unicode characters, it's required to transform `str` to `unicode` (using `decode`). After I fixed the code, it works well.

<img width="355" alt="after" src="https://user-images.githubusercontent.com/1492050/76726840-5017ad00-678d-11ea-99d8-94e1df912331.png">
